### PR TITLE
Add Islamic vs Conventional banking risk study materials

### DIFF
--- a/data/templates/bank_panel_template.csv
+++ b/data/templates/bank_panel_template.csv
@@ -1,0 +1,9 @@
+bank,year,is_islamic,total_assets,total_liabilities,total_equity,net_income,npl_ratio,liquidity_ratio,gdp_growth,inflation,crisis
+Al Rajhi Bank,2018,1,1000000,850000,150000,18000,0.012,0.24,2.4,2.5,0
+Al Rajhi Bank,2019,1,1100000,930000,170000,19000,0.011,0.23,0.3,1.2,0
+Dubai Islamic Bank,2018,1,650000,560000,90000,12000,0.018,0.22,1.4,3.1,0
+Dubai Islamic Bank,2019,1,700000,600000,100000,13000,0.017,0.21,1.3,1.9,0
+Conventional Bank A,2018,0,1050000,920000,130000,15000,0.021,0.19,2.4,2.5,0
+Conventional Bank A,2019,0,1120000,990000,130000,14000,0.023,0.18,0.3,1.2,0
+Conventional Bank B,2018,0,580000,510000,70000,8000,0.026,0.17,1.4,3.1,0
+Conventional Bank B,2019,0,620000,550000,70000,7500,0.027,0.16,1.3,1.9,0

--- a/notebooks/islamic_vs_conventional_banking_risk.ipynb
+++ b/notebooks/islamic_vs_conventional_banking_risk.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Islamic vs Conventional Banking Risk: Data Analysis Notebook\\n",
+    "\\n",
+    "This notebook provides a reproducible workflow for analyzing leverage and stability differences between Islamic and conventional banks using panel data.\\n",
+    "\\n",
+    "**Expected input file:** `data/templates/bank_panel_template.csv` (replace with your full dataset)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\\n",
+    "import pandas as pd\\n",
+    "import matplotlib.pyplot as plt\\n",
+    "\\n",
+    "from linearmodels.panel import PanelOLS\\n",
+    "import statsmodels.api as sm\\n",
+    "\\n",
+    "plt.style.use('seaborn-v0_8-whitegrid')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load data\\n",
+    "path = 'data/templates/bank_panel_template.csv'\\n",
+    "df = pd.read_csv(path)\\n",
+    "\\n",
+    "required_cols = [\\n",
+    "    'bank', 'year', 'is_islamic', 'total_assets', 'total_liabilities',\\n",
+    "    'total_equity', 'net_income', 'npl_ratio', 'liquidity_ratio',\\n",
+    "    'gdp_growth', 'inflation', 'crisis'\\n",
+    "]\\n",
+    "missing = [c for c in required_cols if c not in df.columns]\\n",
+    "assert not missing, f'Missing columns: {missing}'\\n",
+    "\\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Feature engineering\\n",
+    "df['roa'] = df['net_income'] / df['total_assets']\\n",
+    "df['leverage_ratio'] = df['total_liabilities'] / df['total_equity']\\n",
+    "df['equity_to_assets'] = df['total_equity'] / df['total_assets']\\n",
+    "\\n",
+    "df = df.sort_values(['bank', 'year'])\\n",
+    "df['roa_sd_rolling'] = (\\n",
+    "    df.groupby('bank')['roa']\\n",
+    "      .rolling(window=3, min_periods=2)\\n",
+    "      .std()\\n",
+    "      .reset_index(level=0, drop=True)\\n",
+    ")\\n",
+    "df['z_score_proxy'] = (df['roa'] + df['equity_to_assets']) / df['roa_sd_rolling']\\n",
+    "\\n",
+    "df[['bank','year','roa','leverage_ratio','equity_to_assets','z_score_proxy']].head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Descriptive statistics by bank type\\n",
+    "summary = (\\n",
+    "    df.groupby('is_islamic')[['leverage_ratio','equity_to_assets','roa','npl_ratio','liquidity_ratio']]\\n",
+    "      .agg(['mean','median','std'])\\n",
+    ")\\n",
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Trend plot: average leverage by bank type\\n",
+    "trend = df.groupby(['year','is_islamic'])['leverage_ratio'].mean().reset_index()\\n",
+    "\\n",
+    "fig, ax = plt.subplots(figsize=(8,4))\\n",
+    "for k, label in [(1, 'Islamic'), (0, 'Conventional')]:\\n",
+    "    sub = trend[trend['is_islamic'] == k]\\n",
+    "    ax.plot(sub['year'], sub['leverage_ratio'], marker='o', label=label)\\n",
+    "\\n",
+    "ax.set_title('Average Leverage Ratio by Bank Type')\\n",
+    "ax.set_xlabel('Year')\\n",
+    "ax.set_ylabel('Liabilities / Equity')\\n",
+    "ax.legend()\\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Panel regression with fixed effects\\n",
+    "panel_df = df.set_index(['bank', 'year']).copy()\\n",
+    "panel_df['islamic_x_crisis'] = panel_df['is_islamic'] * panel_df['crisis']\\n",
+    "\\n",
+    "y = panel_df['leverage_ratio']\\n",
+    "X = panel_df[['is_islamic', 'crisis', 'islamic_x_crisis', 'roa', 'liquidity_ratio', 'gdp_growth', 'inflation']]\\n",
+    "X = sm.add_constant(X)\\n",
+    "\\n",
+    "model = PanelOLS(y, X, entity_effects=True, time_effects=True, drop_absorbed=True)\\n",
+    "res = model.fit(cov_type='clustered', cluster_entity=True)\\n",
+    "print(res.summary)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notes for real-data implementation\\n",
+    "\\n",
+    "1. Expand the panel to more banks and years for statistical power.\\n",
+    "2. Replace template data with audited/reporting data.\\n",
+    "3. Run robustness checks: alternate dependent variables, crisis subsamples, and matched samples.\\n",
+    "4. Consider endogeneity strategies (IV, DiD, dynamic panel methods)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/research/islamic-vs-conventional-banking-risk/research_report.md
+++ b/research/islamic-vs-conventional-banking-risk/research_report.md
@@ -1,0 +1,98 @@
+# Comparative Study: Islamic vs Conventional Banking Risk
+
+## 1) Research question
+This project evaluates whether Islamic banks display different leverage and stability patterns relative to conventional peers.
+
+Primary questions:
+1. Are Islamic banks less leveraged than conventional banks?
+2. Do Islamic banks perform differently during systemic stress periods?
+3. How does the profit-and-loss sharing orientation affect risk outcomes?
+
+## 2) Motivation
+Islamic banks are constrained by Shariah principles, including the prohibition of interest (riba), stronger asset-backing requirements, and greater emphasis on risk sharing. These features may influence balance-sheet structure, funding composition, and resilience.
+
+## 3) Institutions and sample design
+### Islamic examples
+- **Al Rajhi Bank** (Saudi Arabia)
+- **Dubai Islamic Bank** (UAE)
+
+### Conventional comparison group
+Use a matched peer set by:
+- geography (GCC/MENA markets first, then broader EM/DM peers),
+- size (total assets quantiles),
+- business model (retail-focused vs universal bank),
+- listing status and reporting frequency.
+
+### Suggested panel setup
+- Frequency: annual or quarterly.
+- Horizon: at least 10 years if available (to capture normal and stress episodes).
+- Unit: bank-year (or bank-quarter).
+
+## 4) Variables
+### Core dependent variables (risk/stability)
+- **Leverage ratio** = Total liabilities / Total equity.
+- **Capital adequacy proxy** = Equity / Total assets.
+- **Z-score proxy for stability** = (ROA + Equity/Assets) / sd(ROA).
+- **NPL ratio** = Non-performing loans / Gross loans.
+
+### Explanatory variables
+- **Islamic dummy** = 1 if Islamic bank, else 0.
+- **Crisis dummy** = 1 in crisis years (e.g., 2008-2009, 2020), else 0.
+- **Islamic × Crisis interaction** to test differential stress performance.
+
+### Controls
+- Bank size (log total assets),
+- profitability (ROA),
+- liquidity ratio,
+- macro controls (GDP growth, inflation, policy rate if relevant).
+
+## 5) Econometric approach
+### Baseline fixed-effects panel
+\[
+Risk_{i,t} = \alpha + \beta_1 Islamic_i + \beta_2 Crisis_t + \beta_3(Islamic_i \times Crisis_t) + \gamma X_{i,t} + \mu_i + \lambda_t + \epsilon_{i,t}
+\]
+
+Where:
+- \(\mu_i\): bank fixed effects,
+- \(\lambda_t\): time fixed effects,
+- clustered SEs by bank.
+
+Interpretation:
+- \(\beta_1\): structural difference in normal periods,
+- \(\beta_3\): relative resilience/vulnerability of Islamic banks in crises.
+
+## 6) Data sources (recommended)
+- Banks' annual reports / investor relations.
+- Regulatory datasets (central banks, IMF FSI where available).
+- Commercial datasets (if accessible): Fitch Connect, S&P Capital IQ, Bloomberg.
+- Market indicators: World Bank, IMF, FRED, OECD.
+
+## 7) Expected outputs
+1. **Descriptive statistics table** by bank type.
+2. **Trend figures** for leverage, ROA, and capital ratios.
+3. **Panel regression table** with FE specifications.
+4. **Crisis subsample robustness checks**.
+
+## 8) Interpretation guide
+Evidence supporting lower risk among Islamic banks would include:
+- lower leverage,
+- higher equity-to-assets,
+- higher Z-score,
+- better relative outcomes in crisis years (positive/less negative interaction effect).
+
+## 9) CV signal
+This project demonstrates:
+- applied econometrics (panel methods),
+- financial statement ratio construction,
+- policy-relevant comparison of banking models,
+- domain knowledge in Islamic finance and risk management.
+
+## 10) Limitations and extensions
+- Classification nuances (hybrid business models).
+- Accounting comparability across jurisdictions.
+- Endogeneity concerns (selection into Islamic model).
+
+Possible extensions:
+- Difference-in-differences around specific regulatory reforms,
+- propensity-score matched sample,
+- alternative stability metrics (distance-to-default, market-based risk).


### PR DESCRIPTION
### Motivation
- Provide a ready-to-use research starter for comparing Islamic and conventional banks focused on leverage and stability, suitable for a reproducible analysis.

### Description
- Add `research/islamic-vs-conventional-banking-risk/research_report.md` with research questions, institution scope (Al Rajhi, Dubai Islamic), variable definitions, FE panel specification, interpretation guidance and extensions. 
- Add `data/templates/bank_panel_template.csv` containing a small sample panel with bank-year rows and key financial and macro fields. 
- Add `notebooks/islamic_vs_conventional_banking_risk.ipynb` notebook scaffold that covers data loading/validation, feature engineering (ROA, leverage, equity/assets, z-score proxy), descriptive statistics, trend plotting, and a fixed-effects panel regression using `PanelOLS`. 
- Validate the notebook JSON structure to ensure the notebook file is well-formed. 

### Testing
- Ran `python -m json.tool notebooks/islamic_vs_conventional_banking_risk.ipynb` which succeeded and returned `OK`. 
- Attempted to run a quick CSV check using `pandas`, which failed because `pandas` is not installed in the execution environment. 
- Attempted to create the notebook programmatically with `nbformat`, which failed in this environment due to missing `nbformat`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaacbca3208328b0e56c0803046311)